### PR TITLE
Update CI to use setup-gap@v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: gap-actions/setup-gap@v3
       - uses: gap-actions/install-pkg@v1
         with:
-          packages: "meataxe64"
+          packages: "gap-packages/meataxe64"
       - uses: gap-actions/build-pkg@v3
         with:
           extra-pkgs: "io profiling Gauss datastructures meataxe64"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,32 +19,32 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.16
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
+        gap-version:
+          - 'devel'   # current GAP development version from git
+          - 'latest'  # latest GAP release
+          - 'minimal' # oldest GAP release supported by this package
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAP_PKGS_TO_CLONE: "meataxe64"
-          GAP_PKGS_TO_BUILD: "io profiling Gauss datastructures meataxe64"
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/install-pkg@v1
         with:
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
+          packages: "meataxe64"
+      - uses: gap-actions/build-pkg@v3
+        with:
+          extra-pkgs: "io profiling Gauss datastructures meataxe64"
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/run-pkg-tests@v4
+        with:
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -56,11 +56,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
+      - uses: gap-actions/install-pkg@v1
         with:
-          GAP_PKGS_TO_CLONE: "meataxe64"
-          GAP_PKGS_TO_BUILD: "io profiling Gauss datastructures meataxe64"
-      - uses: gap-actions/build-pkg-docs@v1
+          packages: "meataxe64"
+      - uses: gap-actions/build-pkg@v3
+        with:
+          extra-pkgs: "io profiling Gauss datastructures meataxe64"
+      - uses: gap-actions/build-pkg-docs@v2
         with:
           use-latex: 'true'
       - name: 'Upload documentation'


### PR DESCRIPTION
Update the CI workflow to use current gap-actions releases, migrate legacy inputs, and standardize the GAP version matrix.